### PR TITLE
Add questions as a list and minor admin edits

### DIFF
--- a/hire_hire/add_question/mixins.py
+++ b/hire_hire/add_question/mixins.py
@@ -29,6 +29,15 @@ class DefaultFilterMixin:
 
 
 class GetOrSetUserCookieIdMixin:
+    def dispatch(self, request, *args, **kwargs):
+        response = self.get_or_set_user_cookie_id(
+            request,
+            super().dispatch,
+            *args,
+            **kwargs,
+        )
+        return response
+
     def get_or_set_user_cookie_id(
         self,
         request,

--- a/hire_hire/api_add_question/serializers.py
+++ b/hire_hire/api_add_question/serializers.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from rest_framework import serializers
 
 from add_question.models import AddQuestion

--- a/hire_hire/api_add_question/serializers.py
+++ b/hire_hire/api_add_question/serializers.py
@@ -6,8 +6,6 @@ from api_add_question.validators import validate_added_questions_per_day_limit
 
 
 class AddQuestionSerializer(serializers.ModelSerializer):
-    extra_data = serializers.SerializerMethodField()
-
     class Meta:
         model = AddQuestion
         fields = '__all__'
@@ -18,19 +16,6 @@ class AddQuestionSerializer(serializers.ModelSerializer):
             AddQuestion.status.field.name,
             AddQuestion.user_cookie_id.field.name,
         )
-
-    def get_extra_data(self, obj):
-        return {
-            'add_questions_for24_count': (
-                AddQuestion.objects.get_24_hours_added_question_count(
-                    self.context.get('request').user,
-                    self.context.get('view').user_cookie_id,
-                )
-            ),
-            'limit_add_questions_per_day': (
-                settings.LIMIT_ADD_QUESTIONS_PER_DAY
-            ),
-        }
 
     def validate(self, attrs):
         validate_added_questions_per_day_limit(

--- a/hire_hire/api_add_question/tests/test_api_add_question.py
+++ b/hire_hire/api_add_question/tests/test_api_add_question.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 
 from django.conf import settings

--- a/hire_hire/api_add_question/tests/test_api_add_question.py
+++ b/hire_hire/api_add_question/tests/test_api_add_question.py
@@ -37,12 +37,12 @@ class TestApiAddQuestion:
 
         for i in range(1, settings.LIMIT_ADD_QUESTIONS_PER_DAY + 1):
             added_question = AddQuestion.objects.get(id=i)
-            data_index = i - 1
+            current_data = data[i - 1]
             assert (
-                added_question.text == data[data_index]['text']
+                added_question.text == current_data['text']
             ), 'Текст вопроса не совпадает!!!'
             assert (
-                added_question.answer == data[data_index]['answer']
+                added_question.answer == current_data['answer']
             ), 'Ответ не совпадает!!!'
             assert (
                 added_question.language == language
@@ -52,7 +52,7 @@ class TestApiAddQuestion:
             ), 'Статус не совпадает!!!'
             assert added_question.author == author, 'Автор не совпадает!!!'
             assert (
-                added_question.user_cookie_id is None if author else not None
+                added_question.user_cookie_id is None if author else True
             ), 'user_cookie_id не совпадает!!!'
 
         assert (
@@ -124,22 +124,20 @@ class TestApiAddQuestion:
         assert AddQuestion.objects.count() == 0, 'В базе уже есть вопросы!!!'
 
         some_datetime = '2020-01-01 01:01:01'
-        data = [
-            {
-                'text': 'Вопрос номер 1?',
-                'answer': 'Ответ номер 1',
-                'language': api_add_question_language_2.id,
-                # below not allowed field
-                'author': api_add_question_user_2.id,
-                'ip_address': '8:8:8:8',
-                'pub_date': some_datetime,
-                'status': AddQuestion.StatusChoice.APPROVED,
-                'user_cookie_id': 'some_fake_user_cookie_id',
-            },
-        ]
+        data = {
+            'text': 'Вопрос номер 1?',
+            'answer': 'Ответ номер 1',
+            'language': api_add_question_language_2.id,
+            # below not allowed field
+            'author': api_add_question_user_2.id,
+            'ip_address': '8:8:8:8',
+            'pub_date': some_datetime,
+            'status': AddQuestion.StatusChoice.APPROVED,
+            'user_cookie_id': 'some_fake_user_cookie_id',
+        }
         response = api_client_auth_user.post(
             path=self.url,
-            data=json.dumps(data),
+            data=json.dumps([data]),
             content_type='application/json',
         )
 
@@ -154,7 +152,7 @@ class TestApiAddQuestion:
             == api_add_question_user_1.id
         ), 'Подмена автора!!!'
         assert (
-            added_question_with_wrong_data.ip_address != data[0]['ip_address']
+            added_question_with_wrong_data.ip_address != data['ip_address']
         ), 'Подмена IP!!!'
         assert (
             added_question_with_wrong_data.pub_date != some_datetime
@@ -165,5 +163,5 @@ class TestApiAddQuestion:
         ), 'Подмена статуса!!!'
         assert (
             added_question_with_wrong_data.user_cookie_id
-            != data[0]['user_cookie_id']
+            != data['user_cookie_id']
         ), 'Подмена user_cookie_id!!!'

--- a/hire_hire/api_add_question/tests/test_api_add_question.py
+++ b/hire_hire/api_add_question/tests/test_api_add_question.py
@@ -130,7 +130,7 @@ class TestApiAddQuestion:
         assert AddQuestion.objects.count() == 0, 'В базе уже есть вопросы!!!'
 
         some_datetime = datetime.datetime(2020, 1, 1, 1, 1, 1).strftime(
-            "%Y-%m-%d %H:%M:%S",
+            '%Y-%m-%d %H:%M:%S',
         )
         data = [
             {

--- a/hire_hire/api_add_question/urls.py
+++ b/hire_hire/api_add_question/urls.py
@@ -2,8 +2,8 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from api_add_question.views import (
-    AddQuestionViewSet,
     AddedQestionsAndLimitView,
+    AddQuestionViewSet,
 )
 
 app_name = 'api_add_question'

--- a/hire_hire/api_add_question/urls.py
+++ b/hire_hire/api_add_question/urls.py
@@ -1,7 +1,10 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from api_add_question.views import AddQuestionViewSet
+from api_add_question.views import (
+    AddQuestionViewSet,
+    AddedQestionsAndLimitView,
+)
 
 app_name = 'api_add_question'
 
@@ -15,4 +18,9 @@ router_v1_add_question.register(
 
 urlpatterns = [
     path('', include(router_v1_add_question.urls)),
+    path(
+        'added_qestions_and_limit',
+        AddedQestionsAndLimitView.as_view(),
+        name='added_qestions_and_limit',
+    ),
 ]

--- a/hire_hire/api_add_question/validators.py
+++ b/hire_hire/api_add_question/validators.py
@@ -13,5 +13,5 @@ def validate_added_questions_per_day_limit(user, user_cookie_id):
         >= settings.LIMIT_ADD_QUESTIONS_PER_DAY
     ):
         raise serializers.ValidationError(
-            'Вы исчерпали лимит вопросов на день.'
+            'Вы исчерпали лимит вопросов на день.',
         )

--- a/hire_hire/api_add_question/views.py
+++ b/hire_hire/api_add_question/views.py
@@ -26,14 +26,17 @@ class AddQuestionViewSet(
         )
 
     def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data=request.data,
-            many=True,
-            max_length=settings.LIMIT_ADD_QUESTIONS_PER_DAY
+        remaining_question_limit = (
+            settings.LIMIT_ADD_QUESTIONS_PER_DAY
             - AddQuestion.objects.get_24_hours_added_question_count(
                 request.user,
                 self.user_cookie_id,
-            ),
+            )
+        )
+        serializer = self.get_serializer(
+            data=request.data,
+            many=True,
+            max_length=remaining_question_limit,
         )
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)

--- a/hire_hire/api_add_question/views.py
+++ b/hire_hire/api_add_question/views.py
@@ -1,4 +1,7 @@
-from rest_framework import mixins, viewsets
+from django.conf import settings
+from rest_framework import mixins, status, viewsets
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from add_question.mixins import GetOrSetUserCookieIdMixin
 from add_question.models import AddQuestion
@@ -9,24 +12,53 @@ from api_add_question.serializers import AddQuestionSerializer
 class AddQuestionViewSet(
     GetOrSetUserCookieIdMixin,
     mixins.CreateModelMixin,
-    mixins.ListModelMixin,
-    mixins.RetrieveModelMixin,
+    # mixins.ListModelMixin,
+    # mixins.RetrieveModelMixin,
     viewsets.GenericViewSet,
 ):
     queryset = AddQuestion.objects.all()
     serializer_class = AddQuestionSerializer
-
-    def dispatch(self, request, *args, **kwargs):
-        response = self.get_or_set_user_cookie_id(
-            request,
-            super().dispatch,
-            *args,
-            **kwargs,
-        )
-        return response
 
     def perform_create(self, serializer):
         serializer.save(
             ip_address=self.request.META.get('REMOTE_ADDR'),
             **get_user_data_dict(self.request.user, self.user_cookie_id),
         )
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(
+            data=request.data,
+            many=True,
+            max_length=settings.LIMIT_ADD_QUESTIONS_PER_DAY
+            - AddQuestion.objects.get_24_hours_added_question_count(
+                request.user,
+                self.user_cookie_id,
+            ),
+        )
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
+
+
+class AddedQestionsAndLimitView(
+    GetOrSetUserCookieIdMixin,
+    APIView,
+):
+    def get(self, request):
+        data = {
+            'add_questions_for24_count': (
+                AddQuestion.objects.get_24_hours_added_question_count(
+                    request.user,
+                    self.user_cookie_id,
+                )
+            ),
+            'limit_add_questions_per_day': (
+                settings.LIMIT_ADD_QUESTIONS_PER_DAY
+            ),
+        }
+        return Response(data)

--- a/hire_hire/api_add_question/views.py
+++ b/hire_hire/api_add_question/views.py
@@ -12,8 +12,8 @@ from api_add_question.serializers import AddQuestionSerializer
 class AddQuestionViewSet(
     GetOrSetUserCookieIdMixin,
     mixins.CreateModelMixin,
-    # mixins.ListModelMixin,
-    # mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
     viewsets.GenericViewSet,
 ):
     queryset = AddQuestion.objects.all()


### PR DESCRIPTION
Теперь вопросы отправляем листами.
Чуть админку поправил там только 2 поля едитейбл и чуть более компактно.
Тесты переписал, это был адок пока разобрался как запихивать джесоном.